### PR TITLE
README: Add Installation section with import path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 in the Go source files. The method uses suffix tree for serialized ASTs. It ignores values
 of AST nodes, it cares just about the types.
 
+## Installation
+
+```bash
+go get -u github.com/mibk/dupl
+```
+
 ## Usage
 
 It searches in a current directory by default (can be changed using the first argument).
@@ -17,6 +23,6 @@ flag the output could turn into HTML page with duplicate code fragments.
 The reduced output of this command with the following parameters for the [Docker](https://www.docker.com) source code
 looks like [this](http://htmlpreview.github.io/?https://github.com/mibk/dupl/blob/master/_output_example/docker.html).
 
-```
+```bash
 $ dupl -t 200 -html >docker.html
 ```


### PR DESCRIPTION
Even though one can figure out the import path from the url, it's still helpful to display it in readme. Especially because many packages have vanity import paths, so it's not always immediately obvious.