### PR TITLE
output: add plumbing output. Closes #2

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,8 +24,10 @@ var (
 	threshold  = flag.Int("threshold", DefaultThreshold, "minimum token sequence as a clone")
 	serverPort = flag.String("serve", "", "run server at port")
 	addrs      AddrList
-	html       = flag.Bool("html", false, "html output")
 	files      = flag.Bool("files", false, "files names from stdin")
+
+	html     = flag.Bool("html", false, "html output")
+	plumbing = flag.Bool("plumbing", false, "plumbing output for consumption by scripts or tools")
 )
 
 type AddrList []string
@@ -48,6 +50,9 @@ func init() {
 
 func main() {
 	flag.Parse()
+	if *html && *plumbing {
+		log.Fatal("you can have either plumbing or HTML output")
+	}
 	if flag.NArg() > 0 {
 		dir = flag.Arg(0)
 	}
@@ -152,6 +157,8 @@ func getPrinter() output.Printer {
 	fr := new(LocalFileReader)
 	if *html {
 		return output.NewHtmlPrinter(os.Stdout, fr)
+	} else if *plumbing {
+		return output.NewPlumbingPrinter(os.Stdout, fr)
 	}
 	return output.NewTextPrinter(os.Stdout, fr)
 }

--- a/output/plumbing.go
+++ b/output/plumbing.go
@@ -1,0 +1,29 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/mibk/dupl/syntax"
+)
+
+type PlumbingPrinter struct {
+	*TextPrinter
+}
+
+func NewPlumbingPrinter(w io.Writer, fr FileReader) *PlumbingPrinter {
+	return &PlumbingPrinter{NewTextPrinter(w, fr)}
+}
+
+func (p *PlumbingPrinter) Print(dups [][]*syntax.Node) {
+	clones := p.prepareClonesInfo(dups)
+	sort.Sort(byNameAndLine(clones))
+	for i, cl := range clones {
+		nextCl := clones[(i+1)%len(clones)]
+		fmt.Fprintf(p.writer, "%s:%d-%d: duplicate of %s:%d-%d\n", cl.filename, cl.lineStart, cl.lineEnd,
+			nextCl.filename, nextCl.lineStart, nextCl.lineEnd)
+	}
+}
+
+func (p *PlumbingPrinter) Finish() {}

--- a/output/text.go
+++ b/output/text.go
@@ -33,7 +33,14 @@ func NewTextPrinter(w io.Writer, fr FileReader) *TextPrinter {
 func (p *TextPrinter) Print(dups [][]*syntax.Node) {
 	p.cnt++
 	fmt.Fprintf(p.writer, "found %d clones:\n", len(dups))
+	clones := p.prepareClonesInfo(dups)
+	sort.Sort(byNameAndLine(clones))
+	for i, cl := range clones {
+		fmt.Fprintf(p.writer, "  loc %d: %s, line %d-%d,\n", i+1, cl.filename, cl.lineStart, cl.lineEnd)
+	}
+}
 
+func (p *TextPrinter) prepareClonesInfo(dups [][]*syntax.Node) []clone {
 	clones := make([]clone, len(dups))
 	for i, dup := range dups {
 		cnt := len(dup)
@@ -52,11 +59,7 @@ func (p *TextPrinter) Print(dups [][]*syntax.Node) {
 		cl.lineStart, cl.lineEnd = blockLines(file, nstart.Pos, nend.End)
 		clones[i] = cl
 	}
-
-	sort.Sort(byNameAndLine(clones))
-	for i, cl := range clones {
-		fmt.Fprintf(p.writer, "  loc %d: %s, line %d-%d,\n", i+1, cl.filename, cl.lineStart, cl.lineEnd)
-	}
+	return clones
 }
 
 func (p *TextPrinter) Finish() {


### PR DESCRIPTION
An example of the plumbing output as suggested in #2:
```
$ dupl -t 30 -plumbing
syntax/golang/golang.go:97-105: duplicate of syntax/golang/golang.go:133-140
syntax/golang/golang.go:133-140: duplicate of syntax/golang/golang.go:97-105
syntax/golang/golang.go:146-153: duplicate of syntax/golang/golang.go:155-162
syntax/golang/golang.go:155-162: duplicate of syntax/golang/golang.go:146-153
syntax/golang/golang.go:221-229: duplicate of syntax/golang/golang.go:255-263
syntax/golang/golang.go:255-263: duplicate of syntax/golang/golang.go:221-229
syntax/golang/golang.go:235-240: duplicate of syntax/golang/golang.go:352-357
syntax/golang/golang.go:352-357: duplicate of syntax/golang/golang.go:235-240
output/output_test.go:15-20: duplicate of output/output_test.go:33-38
output/output_test.go:33-38: duplicate of output/output_test.go:15-20
```

Note that groups are not dividied. Should it be divided (for example by a blank line)?
