### PR TITLE
printer: fix HTML escaping

### DIFF
--- a/printer/html.go
+++ b/printer/html.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"io"
 	"regexp"
 	"sort"
@@ -10,17 +11,17 @@ import (
 	"github.com/mibk/dupl/syntax"
 )
 
-type html struct {
+type htmlprinter struct {
 	iota int
 	w    io.Writer
 	ReadFile
 }
 
 func NewHTML(w io.Writer, fread ReadFile) Printer {
-	return &html{w: w, ReadFile: fread}
+	return &htmlprinter{w: w, ReadFile: fread}
 }
 
-func (p *html) PrintHeader() error {
+func (p *htmlprinter) PrintHeader() error {
 	_, err := fmt.Fprint(p.w, `<!DOCTYPE html>
 <meta charset="utf-8"/>
 <title>Duplicates</title>
@@ -35,7 +36,7 @@ func (p *html) PrintHeader() error {
 	return err
 }
 
-func (p *html) PrintClones(dups [][]*syntax.Node) error {
+func (p *htmlprinter) PrintClones(dups [][]*syntax.Node) error {
 	p.iota++
 	fmt.Fprintf(p.w, "<h1>#%d found %d clones</h1>\n", p.iota, len(dups))
 
@@ -63,12 +64,13 @@ func (p *html) PrintClones(dups [][]*syntax.Node) error {
 
 	sort.Sort(byNameAndLine(clones))
 	for _, cl := range clones {
-		fmt.Fprintf(p.w, "<h2>%s:%d</h2>\n<pre>%s</pre>\n", cl.filename, cl.lineStart, cl.fragment)
+		fmt.Fprintf(p.w, "<h2>%s:%d</h2>\n<pre>%s</pre>\n", cl.filename, cl.lineStart,
+			html.EscapeString(string(cl.fragment)))
 	}
 	return nil
 }
 
-func (*html) PrintFooter() error { return nil }
+func (*htmlprinter) PrintFooter() error { return nil }
 
 func findLineBeg(file []byte, index int) int {
 	for i := index; i >= 0; i-- {


### PR DESCRIPTION
Fixes this problem (found when running the tool on entire std lib):

![broken_html](https://user-images.githubusercontent.com/1099351/46767264-22534c80-cced-11e8-9c21-79aa14c333c5.png)
